### PR TITLE
Delete .node from kafka brokers

### DIFF
--- a/packaging/rpm/cookbook-http2k.spec
+++ b/packaging/rpm/cookbook-http2k.spec
@@ -45,6 +45,8 @@ esac
 %doc
 
 %changelog
+* Tue Jan 09 2024 Vicente Mesa <vimesa@redborder.com> - 1.0.9-1
+- Delete .node on kafka brokers
 * Mon Dec 18 2023 Vicente Mesa <vimesa@redborder.com> - 1.0.8-1
 - Fix kafka configuration on http2k service
 * Fri Jan 07 2022 David Vanhoucke <dvanhoucke@redborder.com> - 1.0.2-1


### PR DESCRIPTION
* This release deletes the .node from the Kafka brokers on the config of the http2k service